### PR TITLE
fix: prevent Status Checks workflow from running on main branch pushes

### DIFF
--- a/.github/workflows/status-checks.yaml
+++ b/.github/workflows/status-checks.yaml
@@ -11,7 +11,6 @@ on:
       - Performance Testing
     types:
       - completed
-    branches-ignore: [main] # Don't run on main branch pushes
   workflow_dispatch:
 
 permissions:
@@ -32,7 +31,9 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'cancelled' && github.ref != 'refs/heads/main')
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion != 'cancelled' && 
+       !(github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'))
     outputs:
       ci-status: ${{ steps.check-ci.outputs.status }}
       e2e-status: ${{ steps.check-e2e.outputs.status }}


### PR DESCRIPTION
- Removed branches-ignore filter from workflow_run trigger (doesn't work as expected)
- Added proper branch filtering in job condition to check workflow_run.head_branch
- Prevents false positive pending statuses on main branch commits