### PR TITLE
fix: improve Status Checks workflow condition logic

### DIFF
--- a/.github/workflows/status-checks.yaml
+++ b/.github/workflows/status-checks.yaml
@@ -34,9 +34,13 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion != 'cancelled' &&
-        !(
-          github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
-        )
+        github.event.workflow_run.event != 'push'
+      ) ||
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion != 'cancelled' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch != 'main'
       )
     outputs:
       ci-status: ${{ steps.check-ci.outputs.status }}


### PR DESCRIPTION
- Simplified complex boolean logic to avoid GitHub Actions evaluation issues
- Split workflow_run conditions into explicit positive conditions
- This should definitively prevent execution on main branch pushes