### PR TITLE
ci(renovate): reorder commands in `postUpgradeTasks`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>marcusrbrown/renovate-config#4.2.0', ':preserveSemverRanges', 'group:allNonMajor'],
   postUpgradeTasks: {
-    commands: ['pnpm install', 'pnpm run fix', 'pnpm run build'],
+    commands: ['pnpm install', 'pnpm run build', 'pnpm run fix', 'pnpm run fix'],
     executionMode: 'branch',
   },
 }


### PR DESCRIPTION
- Move 'pnpm run build' before 'pnpm run fix' in commands
- Ensure proper execution order for post-upgrade tasks