### PR TITLE
ci(e2e-tests): fix shell script handling in E2E test notifications

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -330,6 +330,9 @@ jobs:
           PR_NUMBER=${{ github.event.pull_request.number }}
           COMMENT_MARKER="<!-- E2E_TEST_NOTIFICATION_v1 -->"
 
+          # Current timestamp
+          CURRENT_DATE=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
           # Search for existing comment from this workflow
           echo "Checking for existing E2E test notification comment..."
           EXISTING_COMMENT_ID=$(gh pr view "${PR_NUMBER}" \
@@ -339,21 +342,27 @@ jobs:
 
           # Build comment body based on test results
           if [[ "${{ needs.test-summary.result }}" == "success" ]]; then
-            COMMENT_BODY="${COMMENT_MARKER}
+            COMMENT_BODY=$(cat <<EOF
+          ${COMMENT_MARKER}
           ✅ **E2E Testing Passed**
 
           All accessibility, visual, and functional tests passed successfully.
 
           **Workflow Run**: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          **Test Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          **Test Date**: ${CURRENT_DATE}
+          EOF
+          )
           else
-            COMMENT_BODY="${COMMENT_MARKER}
+            COMMENT_BODY=$(cat <<EOF
+          ${COMMENT_MARKER}
           ❌ **E2E Testing Failed**
 
           Some tests failed. Please review the test results and fix any failures before merging.
 
           **Workflow Run**: [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          **Test Date**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          **Test Date**: ${CURRENT_DATE}
+          EOF
+          )
           fi
 
           # Update existing comment or create new one
@@ -364,8 +373,8 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "/repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
-              -f body="$COMMENT_BODY"
+              -f body="${COMMENT_BODY}"
           else
             echo "No existing comment found. Creating new comment..."
-            gh pr comment "${PR_NUMBER}" --body "$COMMENT_BODY"
+            gh pr comment "${PR_NUMBER}" --body "${COMMENT_BODY}"
           fi


### PR DESCRIPTION
Use heredoc syntax and proper variable quoting to prevent shell parsing errors in the PR comment notification step.