### PR TITLE
ci(copilot): add setup workflow and instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,92 @@
+# Copilot Instructions
+
+Read `AGENTS.md` at the repo root for the full code map, structure, conventions, and anti-patterns.
+
+## Stack
+
+React 19 + Vite 7 + TypeScript 5.6+ (strict) + pnpm 10.30+ + Node 22+. Pure ESM. Single-page portfolio deployed to GitHub Pages.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile  # Install deps (NEVER npm/yarn)
+pnpm build                      # tsc && vite build → dist/
+pnpm test                       # vitest run (happy-dom)
+pnpm lint                       # ESLint flat config
+pnpm fix                        # ESLint --fix
+```
+
+Always run `pnpm build` and `pnpm test` before pushing. If lint or type-check fails, fix it — do not suppress errors.
+
+## Critical Conventions
+
+### File Naming
+
+- Hook files: **PascalCase** → `UseScrollReveal.ts`, NOT `useScrollReveal.ts`
+- Components: PascalCase → `Navigation.tsx`
+- Utilities/scripts: kebab-case → `analyze-build.ts`
+- Config files: `.yaml` extension, NEVER `.yml`
+
+### TypeScript (strict mode enforced)
+
+```typescript
+// ✅ CORRECT: Named export, explicit types, as const
+export const THEME_OPTIONS = ["light", "dark", "system"] as const
+type ThemeOption = (typeof THEME_OPTIONS)[number]
+
+// ❌ WRONG: default export, enum, any
+export default function MyComponent() {
+  /* ... */
+}
+enum Theme {
+  Light,
+  Dark,
+}
+const data: any = fetchData()
+```
+
+- No `any`, no `@ts-ignore`, no `@ts-expect-error`
+- No enums — use `as const` unions (`erasableSyntaxOnly`)
+- Named exports only — no default exports
+- Pure ESM — `import`/`export` only, never `require()`
+- `verbatimModuleSyntax` — use `import type` for type-only imports
+
+### React
+
+```typescript
+// ✅ CORRECT: Functional component, named export, React.FC
+export const About: React.FC = () => {
+  return <section id="about">{/* ... */}</section>
+}
+
+// ❌ WRONG: class component, default export
+export default class About extends React.Component { /* ... */ }
+```
+
+- Functional components with hooks only
+- Respect `prefers-reduced-motion` in animations
+- No routing — single page with anchor links
+
+### Code Style
+
+- Prettier: **120-character** line width (`@bfra.me/prettier-config/120-proof`)
+- ESLint: flat config in `eslint.config.ts` — NOT `.eslintrc.*`
+- Vitest for testing (NOT Jest) — config is inline in `vite.config.ts`
+- Tests go in co-located `__tests__/` directories next to source
+
+### Adding a Section
+
+1. Create `src/components/sections/NewSection.tsx` (named export, `React.FC`)
+2. Wire it into `src/App.tsx` following the existing pattern
+3. Add tests in `src/components/__tests__/`
+
+### Adding a Hook
+
+1. Create `src/hooks/UseMyHook.ts` (**PascalCase** filename)
+2. Add tests in `src/hooks/__tests__/`
+
+## Security
+
+- Never commit secrets, tokens, or credentials
+- Never add `console.log` with sensitive data
+- Never weaken TypeScript strict settings

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -1,0 +1,34 @@
+---
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+  pull_request:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup project
+        uses: ./.github/actions/setup
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Verify environment
+        run: |
+          echo "Node.js version: $(node --version)"
+          echo "pnpm version: $(pnpm --version)"
+          echo "TypeScript version: $(pnpm exec tsc --version)"
+          echo "Build output:"
+          ls -la dist/

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@ import {defineConfig} from '@bfra.me/eslint-config'
 export default defineConfig(
   {
     name: 'marcusrbrown.github.io',
-    ignores: ['.ai/', '.claude/', '.github/chatmodes/', 'AGENTS.md', 'CLAUDE.md', 'public/'],
+    ignores: ['.ai/', '.claude/', '.github/chatmodes/', 'AGENTS.md', '.github/copilot-instructions.md', 'public/'],
     typescript: true,
     react: true,
     vitest: {


### PR DESCRIPTION
- add `.github/workflows/copilot-setup-steps.yaml` for dispatch/push/PR validation of Copilot setup
- pin `actions/checkout` to a commit SHA and run local setup action before build
- add workflow safeguards and diagnostics (`timeout-minutes`, read-only permissions, environment/build output checks)
- add `.github/copilot-instructions.md` with project stack, commands, naming conventions, TypeScript/React rules, and security guidance